### PR TITLE
Deploy with Docker Swarm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,45 +77,14 @@ node ('Docker') {
         }
         stash includes: 'docker-compose-live.yml,docker-compose-staging.yml', name: 'tryapl-compose'
     }
-    
-    stage('Deploying with Rancher') {
-        withCredentials([
-                string(credentialsId: '99fcd81b-01f3-40bd-9a90-3a9c85065f1e', variable: 'TAE_SALT'),
-                usernamePassword(credentialsId: '02543ae7-7ed9-4448-ba20-6b367d302ecc', passwordVariable: 'SECRETKEY', usernameVariable: 'ACCESSKEY')]) {
-            if (env.BRANCH_NAME.contains('staging')) {
-                sh ("sed -i 's/{{BRANCH}}/${Branch}/g' ./docker-compose-staging.yml")
-                sh '/usr/local/bin/rancher-compose -f ./docker-compose-staging.yml --access-key $ACCESSKEY --secret-key $SECRETKEY --url http://rancher.dyalog.com:8080/v2-beta/projects/1a5/stacks/1st41 -p TryAPL-Staging up --force-upgrade --confirm-upgrade --pull -d'
-            }
-            if (env.BRANCH_NAME.contains('live')) {
-                sh ("sed -i 's/{{BRANCH}}/${Branch}/g' ./docker-compose-live.yml")
-                sh '/usr/local/bin/rancher-compose -f ./docker-compose-live.yml --access-key $ACCESSKEY --secret-key $SECRETKEY --url http://rancher.dyalog.com:8080/v2-beta/projects/1a5/stacks/1st9 -p TryAPL up --force-upgrade --confirm-upgrade --pull -d'
-            }
-        }
-    }
 }
-if (env.BRANCH_NAME.contains('staging')) {
+if (env.BRANCH_NAME.contains('staging') || env.BRANCH_NAME.contains('live')) {
     node (label: 'swarm && gosport') {
         stage('Deploying with Docker Swarm') {
             withCredentials([string(credentialsId: '99fcd81b-01f3-40bd-9a90-3a9c85065f1e', variable: 'TAE_SALT')]) {
                 unstash 'tryapl-compose'
-                sh 'env'
                 // The swarm scripts expect service.yml
-                sh 'mv docker-compose-staging.yml service.yml'
-                sh ("sed -i 's/{{BRANCH}}/${Branch}/g' ./service.yml")
-                r = swarm 'TryAPL'
-                echo r
-            }
-        }
-    }
-}
-if (env.BRANCH_NAME.contains('swarm')) {
-    node (label: 'swarm && gosport') {
-        stage('Deploying with Docker Swarm') {
-            withCredentials([string(credentialsId: '99fcd81b-01f3-40bd-9a90-3a9c85065f1e', variable: 'TAE_SALT')]) {
-                unstash 'tryapl-compose'
-                sh 'env'
-                // The swarm scripts expect service.yml
-                sh 'mv docker-compose-live.yml service.yml'
+                sh "mv docker-compose-${Branch}.yml service.yml"
                 sh ("sed -i 's/{{BRANCH}}/${Branch}/g' ./service.yml")
                 r = swarm 'TryAPL'
                 echo r

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ node ('Docker') {
     }
     stage ('Update Jarvis') {
         withDockerRegistry(credentialsId: '0435817a-5f0f-47e1-9dcc-800d85e5c335') {
-            DockerJarvis=docker.image('dyalog/jarvis:latest')
+            DockerJarvis=docker.image('dyalog/jarvis:1.17.0')
             DockerJarvis.pull()
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ if (env.BRANCH_NAME.contains('swarm')) {
     node (label: 'swarm && gosport') {
         stage('Deploying with Docker Swarm') {
             withCredentials([string(credentialsId: '99fcd81b-01f3-40bd-9a90-3a9c85065f1e', variable: 'TAE_SALT')]) {
-                unstash tryapl-compose
+                unstash 'tryapl-compose'
                 sh 'mv docker-compose-live.yml service.yml'
                 r = swarm 'TryAPL'
                 echo r

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ node ('Docker') {
     }
     stage ('Update Jarvis') {
         withDockerRegistry(credentialsId: '0435817a-5f0f-47e1-9dcc-800d85e5c335') {
-            DockerJarvis=docker.image('dyalog/jarvis:1.17.0')
+            DockerJarvis=docker.image('dyalog/jarvis:v1.17.0')
             DockerJarvis.pull()
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,11 +93,28 @@ node ('Docker') {
         }
     }
 }
+if (env.BRANCH_NAME.contains('staging')) {
+    node (label: 'swarm && gosport') {
+        stage('Deploying with Docker Swarm') {
+            withCredentials([string(credentialsId: '99fcd81b-01f3-40bd-9a90-3a9c85065f1e', variable: 'TAE_SALT')]) {
+                unstash 'tryapl-compose'
+                sh 'env'
+                // The swarm scripts expect service.yml
+                sh 'mv docker-compose-staging.yml service.yml'
+                sh ("sed -i 's/{{BRANCH}}/${Branch}/g' ./service.yml")
+                r = swarm 'TryAPL'
+                echo r
+            }
+        }
+    }
+}
 if (env.BRANCH_NAME.contains('swarm')) {
     node (label: 'swarm && gosport') {
         stage('Deploying with Docker Swarm') {
             withCredentials([string(credentialsId: '99fcd81b-01f3-40bd-9a90-3a9c85065f1e', variable: 'TAE_SALT')]) {
                 unstash 'tryapl-compose'
+                sh 'env'
+                // The swarm scripts expect service.yml
                 sh 'mv docker-compose-live.yml service.yml'
                 sh ("sed -i 's/{{BRANCH}}/${Branch}/g' ./service.yml")
                 r = swarm 'TryAPL'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,6 +99,7 @@ if (env.BRANCH_NAME.contains('swarm')) {
             withCredentials([string(credentialsId: '99fcd81b-01f3-40bd-9a90-3a9c85065f1e', variable: 'TAE_SALT')]) {
                 unstash 'tryapl-compose'
                 sh 'mv docker-compose-live.yml service.yml'
+                sh ("sed -i 's/{{BRANCH}}/${Branch}/g' ./service.yml")
                 r = swarm 'TryAPL'
                 echo r
             }

--- a/docker-compose-live.yml
+++ b/docker-compose-live.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.6'
 services:
   web:
     image: dyalog/jarvis:latest
@@ -13,5 +13,26 @@ services:
       TAE_SALT: ${TAE_SALT}
       RIDE_INIT: SERVE:*:4502
       APLCORENAME: /storage/aplcore_182U64_*
-    ports:
-    - 4566:4502/tcp
+    networks:
+    - traefik-public
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 512M
+      labels:
+        - traefik.enable=true
+        - traefik.docker.network=traefik-public
+        - traefik.constraint-label=traefik-public
+        - traefik.http.routers.tryapl-http.rule=Host(`tryapl.gos.dyalog.com`,`tryapl.org`,`tryapl.org`,`www.tryapl.com`,`tryapl.com`)
+        - traefik.http.routers.tryapl-http.entrypoints=http
+        - traefik.http.routers.tryapl-http.middlewares=https-redirect
+        - traefik.http.routers.tryapl-https.rule=Host(`tryapl.gos.dyalog.com`,`tryapl.org`,`tryapl.org`,`www.tryapl.com`,`tryapl.com`)
+        - traefik.http.routers.tryapl-https.entrypoints=https
+        - traefik.http.routers.tryapl-https.tls=true
+        - traefik.http.routers.tryapl-https.tls.certresolver=le
+        - traefik.http.services.tryapl.loadbalancer.server.port=8080
+
+networks:
+  traefik-public:
+    external: true

--- a/docker-compose-live.yml
+++ b/docker-compose-live.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   web:
-    image: dyalog/jarvis:latest
+    image: dyalog/jarvis:v1.17.0
     stdin_open: true
     volumes:
     - /DockerVolumes/ftp/tryaplweb/{{BRANCH}}:/app

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   web:
-    image: dyalog/jarvis:latest
+    image: dyalog/jarvis:v1.17.0
     stdin_open: true
     volumes:
     - /DockerVolumes/ftp/tryaplweb/{{BRANCH}}:/app
@@ -24,7 +24,7 @@ services:
         - traefik.enable=true
         - traefik.docker.network=traefik-public
         - traefik.constraint-label=traefik-public
-        - traefik.http.routers.tryapl-http.rule=Host(`stagin.tryapl.org`)
+        - traefik.http.routers.tryapl-http.rule=Host(`staging.tryapl.org`)
         - traefik.http.routers.tryapl-http.entrypoints=http
         - traefik.http.routers.tryapl-http.middlewares=https-redirect
         - traefik.http.routers.tryapl-https.rule=Host(`staging.tryapl.org`)

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.6'
 services:
   web:
     image: dyalog/jarvis:latest
@@ -13,5 +13,26 @@ services:
       TAE_SALT: ${TAE_SALT}
       RIDE_INIT: SERVE:*:4502
       APLCORENAME: /storage/aplcore_182U64_*
-#    ports:
-#    - 4566:4502/tcp
+    networks:
+    - traefik-public
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 512M
+      labels:
+        - traefik.enable=true
+        - traefik.docker.network=traefik-public
+        - traefik.constraint-label=traefik-public
+        - traefik.http.routers.tryapl-http.rule=Host(`stagin.tryapl.org`)
+        - traefik.http.routers.tryapl-http.entrypoints=http
+        - traefik.http.routers.tryapl-http.middlewares=https-redirect
+        - traefik.http.routers.tryapl-https.rule=Host(`staging.tryapl.org`)
+        - traefik.http.routers.tryapl-https.entrypoints=https
+        - traefik.http.routers.tryapl-https.tls=true
+        - traefik.http.routers.tryapl-https.tls.certresolver=le
+        - traefik.http.services.tryapl.loadbalancer.server.port=8080
+
+networks:
+  traefik-public:
+    external: true


### PR DESCRIPTION
This will replace the current deployment method from Rancher to Docker Swarm. 

This PR needs to make it's way all the way from Master -> Staging -> Live - but we should review once it hits staging.

This will additionally use a fixed version of Jarvis as Swarm will never update a "latest" container if it has one, We can likely automate a PR to bump the Jarvis version when it becomes available.