### PR TITLE
Update staging area and use unique stack name for staging/master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ node ('Docker') {
     }
     
     stage ('Publish Try APL') {
-        if ((Branch == 'live') || (Branch == 'Staging') || (Branch == 'swarm')) {
+        if ((Branch == 'live') || (Branch == 'staging') || (Branch == 'swarm')) {
             ftpPublisher alwaysPublishFromMaster: false, continueOnError: false, failOnError: false, publishers: [[
                 configName: 'TryAPLFTP',
                 transfers: [[
@@ -86,7 +86,7 @@ if (env.BRANCH_NAME.contains('staging') || env.BRANCH_NAME.contains('live')) {
                 // The swarm scripts expect service.yml
                 sh "mv docker-compose-${Branch}.yml service.yml"
                 sh ("sed -i 's/{{BRANCH}}/${Branch}/g' ./service.yml")
-                r = swarm 'TryAPL'
+                r = swarm "TryAPL-${Branch}"
                 echo r
             }
         }


### PR DESCRIPTION
Staging area had an upper case S, but we were doing a toLowerCase() so this should never have passed, and the stack was always called "TryAPL" it is now named "TryAPL-${Branch}" so that staging doesn't wipe out live, and also so it's clearer on the server of which stack is which.