### PR TITLE
WIBNI: lang bar tooltils have links to docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
          	   })();
         	</script>
        <!-- End Matomo Code -->
-		
+		<script src="lib/tooltips.js"></script>
 	</head>
 	<body>
 		<i accesskey="w" onclick="html.className=this.accessKey;localStorage.setItem('darkMode','w');"></i>
@@ -488,5 +488,16 @@ session.value=session.value.slice(0,session.selectionStart)
 		</div>
 	</div>
 	<script src="lib/tiolb.js"></script>
+	<script>
+		document.querySelectorAll('.ngn_lb b').forEach(function(glyph) {
+			glyph.addEventListener('click', function(event) {
+				if (event.ctrlKey) {
+					var symbol = event.target.textContent;
+					var url = 'https://help.dyalog.com/latest/#Language/Primitive%20Functions%20and%20Operators/' + encodeURIComponent(symbol) + '.htm';
+					window.open(url, '_blank');
+				}
+			});
+		});
+	</script>
 	</body>
 </html>

--- a/lib/tiolb.js
+++ b/lib/tiolb.js
@@ -75,6 +75,18 @@ let upd=_=>{
 }
 upd();ev(window,'resize',upd)
 ev(d,'focus',ff,!0);let ae=d.activeElement;ae&&ff({type:'focus',target:ae})
+
+// Add event listener to handle Ctrl+click on language bar glyphs
+document.querySelectorAll('.ngn_lb b').forEach(function(element) {
+  element.addEventListener('click', function(event) {
+    if (event.ctrlKey) {
+      var symbol = event.target.textContent;
+      var url = 'https://help.dyalog.com/latest/#Language/Primitive%20Functions/' + encodeURIComponent(symbol) + '.htm';
+      window.open(url, '_blank');
+    }
+  });
+});
+
 })();
 show=_=>{document.querySelector(".ngn_lb").style.display = ''
           session.style.height="calc(-58px + 100vh)"

--- a/lib/tooltips.js
+++ b/lib/tooltips.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const tooltips = document.querySelectorAll('.ngn_lb b');
+  tooltips.forEach(function(tooltip) {
+    tooltip.addEventListener('mouseover', function(event) {
+      const symbol = event.target.textContent;
+      const url = 'https://help.dyalog.com/latest/#Language/Primitive%20Functions%20and%20Operators/' + encodeURIComponent(symbol) + '.htm';
+      const tooltipContent = event.target.getAttribute('title') + '\nDocumentation: ' + url;
+      event.target.setAttribute('title', tooltipContent);
+    });
+  });
+});

--- a/lib/tryapl.js
+++ b/lib/tryapl.js
@@ -1,4 +1,3 @@
-// TryAPL callbacks & text session handling
 var tryaplversion = "3.6.1"
 var prevCount = 0
 var debug = false
@@ -607,3 +606,14 @@ const checkPaneWidth = (width) => {
 		$$("#tabs svg").forEach(e=>e.style.display="unset")
 	}
 }
+
+// Add event listener to handle Ctrl+click on language bar glyphs
+document.querySelectorAll('.ngn_lb b').forEach(function(element) {
+  element.addEventListener('click', function(event) {
+    if (event.ctrlKey) {
+      var symbol = event.target.textContent;
+      var url = 'https://help.dyalog.com/latest/#Language/Primitive%20Functions/' + encodeURIComponent(symbol) + '.htm';
+      window.open(url, '_blank');
+    }
+  });
+});


### PR DESCRIPTION
Fixes #10

Add links to documentation in tooltips and handle Ctrl+click on language bar glyphs.

* Add a script tag in `index.html` to include the new `lib/tooltips.js` file.
* Add an event listener in `index.html` to handle Ctrl+click on language bar glyphs and open the documentation link in a new browser tab.
* Add an event listener in `lib/tiolb.js` to handle Ctrl+click on language bar glyphs and open the documentation link in a new browser tab.
* Add an event listener in `lib/tryapl.js` to handle Ctrl+click on language bar glyphs and open the documentation link in a new browser tab.
* Create a new file `lib/tooltips.js` to add links to documentation in tooltips when hovering over language bar glyphs.

