### PR TITLE
Add case significance in language bar tips

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,6 +321,16 @@ session.value=session.value.slice(0,session.selectionStart)
 <code class="apl" onclick="ins(this)">⎕D     </code>&emsp;<a href="https://help.dyalog.com/latest/Content/Language/System%20Functions/d.htm" target="_blank">Digits</a><br />
 <code class="apl" onclick="ins(this)">⎕DL    </code>&emsp;<a href="https://help.dyalog.com/latest/Content/Language/System%20Functions/dl.htm" target="_blank">Delay</a><br />
 
+<h2 id="significance">Significance of Case in Language Bar Tips</h2>
+<p>The language bar tips in TryAPL use different cases to represent different types of elements. Understanding these cases can help you use the language bar more effectively.</p>
+<h3>Functions</h3>
+<p>Functions are represented in lowercase. For example, the addition function is represented as <code class="apl">+</code>.</p>
+<h3>Operators</h3>
+<p>Operators are represented in uppercase. For example, the reduction operator is represented as <code class="apl">/</code>.</p>
+<h3>Miscellaneous Syntax</h3>
+<p>Miscellaneous syntax elements are represented in mixed case. For example, the assignment symbol is represented as <code class="apl">←</code>.</p>
+<p>By understanding these cases, you can quickly identify the type of element you are working with in the language bar tips.</p>
+
 		<br/></div>
 		<div class="content" id="links">
 			<h1>Useful links</h1>


### PR DESCRIPTION
Fixes #46

Add a new section in the help tab to address the significance of case in the language bar tips.

* Add a new section titled "Significance of Case in Language Bar Tips" in `index.html`.
* Explain the different cases used for functions, operators, and miscellaneous syntax in the language bar tips.
* Provide examples of how to use the different cases in the language bar tips.
