### PR TITLE
Update TryAPL config for Dyalog v20.0

### DIFF
--- a/docker-compose-live.yml
+++ b/docker-compose-live.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   web:
-    image: dyalog/jarvis:dyalog-v20.0-20250702
+    image: dyalog/jarvis:dyalog-v20.0
     stdin_open: true
     volumes:
     - /DockerVolumes/ftp/tryaplweb/{{BRANCH}}:/app

--- a/docker-compose-live.yml
+++ b/docker-compose-live.yml
@@ -12,7 +12,7 @@ services:
     environment:
       TAE_SALT: ${TAE_SALT}
       RIDE_INIT: SERVE:*:4502
-      APLCORENAME: /storage/aplcore_182U64_*
+      APLCORENAME: /storage/aplcore_TryAPL_200U64_*
     networks:
     - traefik-public
     deploy:

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   web:
-    image: dyalog/jarvis:dyalog-v20.0-20250702
+    image: dyalog/jarvis:dyalog-v20.0
     stdin_open: true
     volumes:
     - /DockerVolumes/ftp/tryaplweb/{{BRANCH}}:/app

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -12,7 +12,7 @@ services:
     environment:
       TAE_SALT: ${TAE_SALT}
       RIDE_INIT: SERVE:*:4502
-      APLCORENAME: /storage/aplcore_182U64_*
+      APLCORENAME: /storage/aplcore_TryAPL_200U64_*
     networks:
     - traefik-public
     deploy:


### PR DESCRIPTION
- Use dyalog/jarvs:dyalog-v20.0 containers
  fix #80
- Update aplcore names for TryAPL on Dyalog v20.0
  fix #72 